### PR TITLE
Keep 'previous' references consistent client-side

### DIFF
--- a/collection/OrderedAddMixin.js
+++ b/collection/OrderedAddMixin.js
@@ -23,6 +23,7 @@ module.exports = {
     }
     var options = _.extend({}, options, {at:0})
     var added = this.add(newModel, options);
+    added.set('previous', false);
     return added;
   }
 

--- a/test/CollectionOrderSpec.js
+++ b/test/CollectionOrderSpec.js
@@ -279,6 +279,10 @@ describe("Collection order", function() {
       expect(model1.get('previous')).to.equal('2');
     });
 
+    it("A total of three units may get new 'previous' at move", function() {
+      expect("TODO").to.equal("implemented");
+    });
+
     it("Can move #first", function() {
       var c = new Collection();
       var model1 = c.add(new Model({id:'1', type:'text', content: 'p1', previous: false}));

--- a/test/CollectionOrderSpec.js
+++ b/test/CollectionOrderSpec.js
@@ -47,6 +47,11 @@ describe("Collection order", function() {
       expect(c.at(2)).to.equal(m2);
     });
 
+    it("Sets a 'previous' attribute", function() {
+      expect(m3.has('previous')).to.be.true;
+      expect(m3.get('previous')).to.be.a('string').and.equal('t1');
+    });
+
     it("Can't be used to re-arrange items already in the collection", function() {
       expect(function() {
         c.addAfter(m2, m3);

--- a/test/CollectionOrderSpec.js
+++ b/test/CollectionOrderSpec.js
@@ -71,6 +71,14 @@ describe("Collection order", function() {
       expect(onAdd.calls).to.have.length(2);
     });
 
+    it("Changes 'previous' attribute of the next unit", function() {
+      expect('TODO').to.equal('implemented');
+    });
+
+    it("Avoids setting 'previous' attribute of the next unit if it had no 'previous' before", function() {
+      expect('TODO').to.equal('implemented');
+    });
+
   });
 
   describe("#addFirst", function() {
@@ -111,6 +119,14 @@ describe("Collection order", function() {
       expect(onAdd.calls).to.have.length(1);
     });
 
+    it("Changes 'previous' attribute of the next unit", function() {
+      expect('TODO').to.equal('implemented');
+    });
+
+    it("Avoids setting 'previous' attribute of the next unit if it had no 'previous' before", function() {
+      expect('TODO').to.equal('implemented');
+    });
+
   });
 
   describe("#delete", function() {
@@ -136,6 +152,10 @@ describe("Collection order", function() {
       expect(c).to.have.length(1);
       c.remove(model1);
       expect(c).to.have.length(0);
+    });
+
+    it("Does not change 'previous' attribute of the next unit, so backend can detect misuse", function() {
+      expect('TODO').to.equal('implemented');
     });
 
   });
@@ -173,12 +193,13 @@ describe("Collection order", function() {
       expect(c.at(1).get('content')).to.equal('p1');
       expect(c.down).to.be.undefined;
       expect(model2.get('previous')).to.be.a('boolean').and.equal(false);
+      expect(model1.has('previous')).to.be.false; // had no 'previous' before
     });
 
     it("Emits delete and add events, with extra option modelMove:true", function() {
       var c = new Collection();
       var model0 = c.add(new Model({id: 0, type:'t', content: '-'}));
-      var model1 = c.add(new Model({id: 1, type:'t', content: 'x'}));
+      var model1 = c.add(new Model({id: 1, type:'t', content: 'x', previous: 0}));
       var model2 = c.add(new Model({id: 2, type:'t', content: 'y'}));
       var events = mocks.spy();
       c.on('add', events);
@@ -188,6 +209,7 @@ describe("Collection order", function() {
       expect(events.calls[0].args[0].get('deleted')).to.be.true;
       expect(events.calls[1].args[2]).to.deep.equal({merge:false, add:true, remove:false, at:1, index:1, modelMove:true, myoption:'here'});
       expect(model2.get('previous')).to.be.a('number').and.equal(0);
+      expect(model1.get('previous')).to.equal(2);
     });
 
     it("Delete through collection.move(model1).out()", function() {
@@ -259,12 +281,13 @@ describe("Collection order", function() {
 
     it("Can move #first", function() {
       var c = new Collection();
-      var model1 = c.add(new Model({id:'1', type:'text', content: 'p1'}));
+      var model1 = c.add(new Model({id:'1', type:'text', content: 'p1', previous: false}));
       var model2 = c.add(new Model({id:'2', type:'text', content: 'p2'}));
       c.move(model2).first();
       expect(c.size()).to.equal(3);
       expect(c.at(0).get('content')).to.equal('p2');
       expect(model2.get('previous')).to.be.a('boolean').and.equal(false);
+      expect(model1.get('previous')).to.equal('2');
     });
 
     // This is useful for internal robustness as well so let's expose it

--- a/test/CollectionOrderSpec.js
+++ b/test/CollectionOrderSpec.js
@@ -90,6 +90,11 @@ describe("Collection order", function() {
       expect(c2.at(1)).to.equal(m4);
     });
 
+    it("Sets the 'previous' attribute to boolean false", function() {
+      expect(m4.has('previous')).to.be.true;
+      expect(m4.get('previous')).to.be.a('boolean').and.equal(false);
+    });
+
     it("Also doesn't accept already present models", function() {
       expect(function() {
         c2.addFirst(m4);

--- a/test/CollectionOrderSpec.js
+++ b/test/CollectionOrderSpec.js
@@ -105,9 +105,27 @@ describe("Collection order", function() {
 
   describe("#delete", function() {
 
-    it("Does not exist, use .remove or .move(model).out() instead", function() {
+    it("Does not exist, use .move(model).out() instead", function() {
       var c = new Collection();
       expect(c.delete).to.be.undefined;
+    });
+
+  });
+
+  describe("#remove (don't use!)", function() {
+
+    it("Is in the backbone.js API but should normally be avoided in authormodel use", function() {
+      expect(c.remove).to.exist.and.be.a('function');
+    });
+
+    it("Behaves as in backbone, but if you do want to kill a unit use model.destroy instead", function() {
+      var Collection = require('../collection/AuthoringCollectionDefault');
+      var Model = require('../unit/AuthoringUnitDefault');
+      var c = new Collection();
+      var model1 = c.add(new Model({type:'text'}));
+      expect(c).to.have.length(1);
+      c.remove(model1);
+      expect(c).to.have.length(0);
     });
 
   });

--- a/test/CollectionOrderSpec.js
+++ b/test/CollectionOrderSpec.js
@@ -172,6 +172,7 @@ describe("Collection order", function() {
       expect(c.at(0).get('content')).to.equal('p2');
       expect(c.at(1).get('content')).to.equal('p1');
       expect(c.down).to.be.undefined;
+      expect(model2.get('previous')).to.be.a('boolean').and.equal(false);
     });
 
     it("Emits delete and add events, with extra option modelMove:true", function() {
@@ -186,6 +187,7 @@ describe("Collection order", function() {
       expect(events.calls).to.have.length(2);
       expect(events.calls[0].args[0].get('deleted')).to.be.true;
       expect(events.calls[1].args[2]).to.deep.equal({merge:false, add:true, remove:false, at:1, index:1, modelMove:true, myoption:'here'});
+      expect(model2.get('previous')).to.be.a('number').and.equal(0);
     });
 
     it("Delete through collection.move(model1).out()", function() {
@@ -252,6 +254,7 @@ describe("Collection order", function() {
       c.move(model1).toAfter(model2);
       expect(c.size()).to.equal(3);
       expect(c.at(2).get('content')).to.equal('p1');
+      expect(model1.get('previous')).to.equal('2');
     });
 
     it("Can move #first", function() {
@@ -261,6 +264,7 @@ describe("Collection order", function() {
       c.move(model2).first();
       expect(c.size()).to.equal(3);
       expect(c.at(0).get('content')).to.equal('p2');
+      expect(model2.get('previous')).to.be.a('boolean').and.equal(false);
     });
 
     // This is useful for internal robustness as well so let's expose it
@@ -271,6 +275,7 @@ describe("Collection order", function() {
       c.move(model2).toBefore(model1);
       expect(c.size()).to.equal(3);
       expect(c.at(0).get('content')).to.equal('p2');
+      expect(model2.get('previous')).to.be.a('boolean').and.equal(false);
     });
 
     // The stateful move object is a problem if the collection changes between creation and execution


### PR DESCRIPTION
At a move we'd need to update any existing 'revoius' of the unit below the destination.
